### PR TITLE
Fix CDN scraping

### DIFF
--- a/scraper/crawlers/movie_crawler.py
+++ b/scraper/crawlers/movie_crawler.py
@@ -1,6 +1,7 @@
 import re
 from bs4 import BeautifulSoup
 import urllib.request
+from scraper.utils.url_utils import thumb_to_cdn
 
 class MovieCrawler:
     def crawl(self, url):
@@ -20,6 +21,8 @@ class MovieCrawler:
             print(f"Error extracting subfolder: {e}")
             return
 
+        thumb_pattern = re.compile(r"^https://moviethumbs.*?fancaps\.net/")
+
         while currentUrl:
             try:
                 # Fetch and parse the webpage
@@ -29,14 +32,14 @@ class MovieCrawler:
             except Exception as e:
                 print(f"Error fetching or parsing page: {e}")
                 break
-            
-            for img in beautifulSoup.find_all("img", src=re.compile("^https://moviethumbs.fancaps.net/")):
+
+            for img in beautifulSoup.find_all("img", src=thumb_pattern):
                 imgSrc = img.get("src")
                 imgAlt = img.get("alt")
                 if not alt:
                     alt = imgAlt
                 if alt == imgAlt:
-                    picLinks.append(imgSrc.replace("https://moviethumbs.fancaps.net/", "https://mvcdn.fancaps.net/"))
+                    picLinks.append(thumb_to_cdn(imgSrc))
             
             try:
                 # Generate and verify the existence of the next page URL

--- a/scraper/utils/url_utils.py
+++ b/scraper/utils/url_utils.py
@@ -1,0 +1,13 @@
+import re
+from urllib.parse import urlparse, urlunparse
+
+
+def thumb_to_cdn(url: str) -> str:
+    """Convert a thumbnail URL to its CDN counterpart.
+
+    This replaces the "thumbs" subdomain segment with "cdn" while preserving
+    any additional subdomain parts (e.g. tvthumbs1 -> tvcdn1).
+    """
+    parsed = urlparse(url)
+    cdn_host = re.sub(r"thumbs", "cdn", parsed.netloc, count=1)
+    return urlunparse(parsed._replace(netloc=cdn_host))


### PR DESCRIPTION
## Summary
- add URL helper for converting thumbnail hosts to CDN hosts
- use the helper in episode/movie crawlers and match any thumbnail subdomain

## Testing
- `python -m py_compile scraper/utils/url_utils.py scraper/crawlers/episode_crawler.py scraper/crawlers/movie_crawler.py`
- `python -m py_compile scraper/*.py scraper/crawlers/*.py web/fancaps_web.py fancaps-daemon.py fancaps-downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68497b1802448333827f6c2ba588fa81