### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Preview:
 * ✅ Download image galleries from fancaps.net (TV, Anime, Movies)
 * ✅ CLI mode (`fancaps-downloader.py`) for manual and scripted downloads
 * ✅ Daemon mode (`fancaps-daemon.py`) for automatic background processing
+* ✅ Multi-threaded downloads with progress bars and automatic retry
 * ✅ `queue.txt` + `archive.txt` system for organized tracking
 * ✅ Web UI to manage queue entries (add/remove)
 * ✅ Read-only archive view in web UI
+* ✅ Live log viewer in the web UI
 * ✅ Fully runs as a background service (systemd ready)
 
 ---
@@ -48,6 +50,8 @@ pip install beautifulsoup4 tqdm flask
 * `--batch-file`: Path to a text file containing URLs
 * `-?`: Show help message
 
+Downloads run concurrently with progress bars and retry on failures.
+
 ### Supported URLs
 
 * `https://fancaps.net/{tv|anime}/showimages.php?...`
@@ -69,6 +73,7 @@ Batch download from file:
 ```bash
 python fancaps-downloader.py --batch-file "batch.txt" --batch-type season --output "SeasonDownloads"
 ```
+You can also run the CLI via `python -m fancaps.cli`.
 
 ---
 
@@ -99,6 +104,7 @@ Test manually:
 ```bash
 python3 fancaps-daemon.py
 ```
+The daemon reads `/opt/fancaps/queue.txt` every 5 minutes and saves files to `/opt/fancaps/downloads`.
 
 Run as service:
 
@@ -150,6 +156,7 @@ Access via:
 http://<server-ip>:5080
 ```
 
+A real-time log view is available at `http://<server-ip>:5080/log`.
 ### Optional Auto-Start (systemd):
 
 ```ini


### PR DESCRIPTION
## Summary
- document multi-threaded downloader and log viewer
- mention concurrency notes for CLI
- add daemon polling detail and web log endpoint

## Testing
- `python3 -m py_compile fancaps/*.py scraper/*.py scraper/crawlers/*.py scraper/utils/*.py web/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68497e2fd9788333943f7fd22800431b