### PR TITLE
Fix crawler robustness and CLI URL detection

### DIFF
--- a/fancaps/cli.py
+++ b/fancaps/cli.py
@@ -5,7 +5,7 @@ from . import Crawler, Downloader, Colors, UrlSupport
 
 
 def process_single_url(url: str, output: str) -> None:
-    url_type = UrlSupport.getType(url)
+    url_type = UrlSupport().getType(url)
     Colors.print(f"URL-Typ: {url_type}", Colors.CYAN)
 
     if url_type not in {"season", "movie", "episode"}:

--- a/scraper/crawler.py
+++ b/scraper/crawler.py
@@ -23,5 +23,13 @@ class Crawler:
         else:
             return []
 
-        Colors.print(f"{url} crawling finished.",Colors.YELLOW)
+        Colors.print(f"{url} crawling finished.", Colors.YELLOW)
+        empty = True
+        for item in output:
+            if item.get("links"):
+                empty = False
+            else:
+                Colors.print("No images found for this entry. The page may be blocked or invalid.", Colors.WARNING)
+        if empty:
+            Colors.print("No image links parsed from URL. Possible blocking or invalid URL.", Colors.WARNING)
         return output

--- a/scraper/crawlers/movie_crawler.py
+++ b/scraper/crawlers/movie_crawler.py
@@ -1,6 +1,6 @@
 import re
 from bs4 import BeautifulSoup
-import urllib.request
+import cloudscraper
 from scraper.utils.url_utils import thumb_to_cdn
 
 class MovieCrawler:
@@ -23,14 +23,17 @@ class MovieCrawler:
 
         thumb_pattern = re.compile(r"^https://moviethumbs.*?fancaps\.net/")
 
+        scraper = cloudscraper.create_scraper()
+
         while currentUrl:
             try:
-                # Fetch and parse the webpage
-                request = urllib.request.Request(currentUrl, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0'})
-                page = urllib.request.urlopen(request)
-                beautifulSoup = BeautifulSoup(page, "html.parser")
+                response = scraper.get(currentUrl, timeout=10)
+                if 'cf-browser-verification' in response.text:
+                    print('Cloudflare challenge detected. Aborting.')
+                    break
+                beautifulSoup = BeautifulSoup(response.text, "html.parser")
             except Exception as e:
-                print(f"Error fetching or parsing page: {e}")
+                print(f"Error fetching page: {e}")
                 break
 
             for img in beautifulSoup.find_all("img", src=thumb_pattern):
@@ -58,3 +61,4 @@ class MovieCrawler:
             'subfolder': subfolder,
             'links': picLinks
         }
+

--- a/scraper/utils/colors.py
+++ b/scraper/utils/colors.py
@@ -6,6 +6,10 @@ class Colors:
     BLUE = '\033[94m'
     PURPLE = '\033[95m'
     CYAN = '\033[96m'
+    FAIL = RED
+    WARNING = YELLOW
 
-    def print(text, color):
-        print(color + text + Colors.RESET)
+    @staticmethod
+    def print(text: str, color: str = RESET) -> None:
+        print(f"{color}{text}{Colors.RESET}")
+


### PR DESCRIPTION
## Summary
- fix UrlSupport invocation in CLI
- add missing FAIL and WARNING colors
- detect Cloudflare challenge and use cloudscraper in crawlers
- warn when crawlers return no images

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6849aae036a88333bcfa02874cedeb62