### PR TITLE
Add venv support to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Preview:
 * Python 3.8+
 * Linux system (tested on Debian/Ubuntu)
 * Git
-* `beautifulsoup4`, `tqdm`, `flask`
+* `beautifulsoup4`, `cloudscraper`, `tqdm`, `flask`
 
 Install with:
 
 ```bash
-pip install beautifulsoup4 tqdm flask
+pip install -r requirements.txt
 ```
 
 ---
@@ -95,6 +95,12 @@ mkdir -p /opt/fancaps/downloads
 chmod 775 /opt/fancaps/downloads
 ```
 
+### 3. Install and Enable Services
+
+```bash
+sudo ./install.sh install
+```
+
 ---
 
 ## 🚀 Running the Daemon
@@ -117,7 +123,7 @@ After=network.target
 [Service]
 Type=simple
 User=yourusername
-ExecStart=/usr/bin/python3 /opt/fancaps/fancaps-daemon.py
+ExecStart=/opt/fancaps/venv/bin/python /opt/fancaps/fancaps-daemon.py
 Restart=always
 RestartSec=10
 
@@ -168,7 +174,7 @@ After=network.target
 [Service]
 Type=simple
 User=yourusername
-ExecStart=/usr/bin/python3 /opt/fancaps/web/fancaps_web.py
+ExecStart=/opt/fancaps/venv/bin/python /opt/fancaps/web/fancaps_web.py
 WorkingDirectory=/opt/fancaps/web
 Restart=always
 RestartSec=10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4
+cloudscraper
+tqdm
+flask


### PR DESCRIPTION
## Summary
- manage Python packages with a `requirements.txt`
- update `install.sh` to create and use a virtual environment
- document new installation step and venv-based services

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685556904a748333b4ceb0f725c5af27