### PR TITLE
Add generic crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Preview:
 ## ✨ Features
 
 * ✅ Download image galleries from fancaps.net (TV, Anime, Movies)
+* ✅ Start from any Fancaps page and auto-discover season or movie links
 * ✅ CLI mode (`fancaps-downloader.py`) for manual and scripted downloads
 * ✅ Daemon mode (`fancaps-daemon.py`) for automatic background processing
 * ✅ Multi-threaded downloads with progress bars and automatic retry
@@ -57,6 +58,9 @@ Downloads run concurrently with progress bars and retry on failures.
 * `https://fancaps.net/{tv|anime}/showimages.php?...`
 * `https://fancaps.net/{tv|anime}/episodeimages.php?...`
 * `https://fancaps.net/movies/MovieImages.php?...`
+
+Other Fancaps pages can be given as a base URL. The crawler will scan the page
+for links matching the above patterns and process them automatically.
 
 ⚠️ **Note:** If the URL contains `&`, wrap it in **double quotes**.
 

--- a/scraper/crawler.py
+++ b/scraper/crawler.py
@@ -1,32 +1,58 @@
 from scraper.url_support import UrlSupport
 from scraper.crawlers import episode_crawler, season_crawler, movie_crawler
 from scraper.utils.colors import Colors
+from bs4 import BeautifulSoup
+import cloudscraper
+from urllib.parse import urljoin
 
 class Crawler:
-    def crawl(self, url):
-        Colors.print(f"{url} crawling started:",Colors.YELLOW)
+    def crawl(self, url, visited=None):
+        """Crawl a fancaps URL or generic page for image links."""
+        if visited is None:
+            visited = set()
+        if url in visited:
+            return []
+        visited.add(url)
 
-        urlSupport = UrlSupport()
-        urlType = urlSupport.getType(url)
-        if urlType == 'season':
-            print(f"\t\"{urlType}\" url detected")
+        Colors.print(f"{url} crawling started:", Colors.YELLOW)
+
+        url_support = UrlSupport()
+        url_type = url_support.getType(url)
+
+        if url_type == 'season':
+            print(f"\t\"{url_type}\" url detected")
             crawler = season_crawler.SeasonCrawler()
             output = crawler.crawl(url)
-        elif urlType == 'episode':
-            print(f"\t\"{urlType}\" url detected")
+        elif url_type == 'episode':
+            print(f"\t\"{url_type}\" url detected")
             crawler = episode_crawler.EpisodeCrawler()
             output = [crawler.crawl(url)]
-        elif urlType == 'movie':
-            print(f"\t\"{urlType}\" url detected")
+        elif url_type == 'movie':
+            print(f"\t\"{url_type}\" url detected")
             crawler = movie_crawler.MovieCrawler()
             output = [crawler.crawl(url)]
         else:
-            return []
+            # Generic page handling: find supported links and crawl them
+            Colors.print("\tGeneric page detected. Searching for links...", Colors.BLUE)
+            output = []
+            scraper = cloudscraper.create_scraper()
+            try:
+                response = scraper.get(url, timeout=10)
+                soup = BeautifulSoup(response.text, 'html.parser')
+            except Exception as e:
+                Colors.print(f"Error opening {url}: {e}", Colors.RED)
+                return []
+
+            for anchor in soup.find_all('a', href=True):
+                link = urljoin(url, anchor['href'])
+                if url_support.getType(link):
+                    output.extend(self.crawl(link, visited))
 
         Colors.print(f"{url} crawling finished.", Colors.YELLOW)
+
         empty = True
         for item in output:
-            if item.get("links"):
+            if item.get('links'):
                 empty = False
             else:
                 Colors.print("No images found for this entry. The page may be blocked or invalid.", Colors.WARNING)

--- a/scraper/url_support.py
+++ b/scraper/url_support.py
@@ -9,7 +9,7 @@ class UrlSupport:
 
 
     def getType(self, url):
-        for type, reSupportedUrl in self.reSupportedUrls.items():
-            if re.search(reSupportedUrl, url):
-                return type
+        for url_type, pattern in self.reSupportedUrls.items():
+            if re.search(pattern, url):
+                return url_type
         return None


### PR DESCRIPTION
## Summary
- allow starting from generic pages to auto-discover image links
- fix `UrlSupport.getType` implementation
- document new feature in README

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685559ea75ec8333824ad15e38922c5f