### PR TITLE
Add alt crawler option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install -r requirements.txt
 Run the downloader directly:
 
 ```bash
-python fancaps-downloader.py [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE]
+python fancaps-downloader.py [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE] [--alt]
 ```
 
 Supported links:
@@ -58,6 +58,7 @@ https://fancaps.net/{tv|anime}/episodeimages.php?...
 https://fancaps.net/movies/MovieImages.php?...
 ```
 Wrap URLs containing `&` in quotes.
+Use `--alt` to activate the alternative crawler for season or episode URLs.
 
 ## Notes
 - `queue.txt` is writable via the web interface, `archive.txt` is read only.

--- a/fancaps/cli.py
+++ b/fancaps/cli.py
@@ -1,10 +1,10 @@
 """Command line interface for the Fancaps framework."""
 import argparse
 import os
-from . import Crawler, Downloader, Colors, UrlSupport
+from . import Crawler, AltCrawler, Downloader, Colors, UrlSupport
 
 
-def process_single_url(url: str, output: str) -> None:
+def process_single_url(url: str, output: str, alt: bool = False) -> None:
     url_type = UrlSupport().getType(url)
     Colors.print(f"URL-Typ: {url_type}", Colors.CYAN)
 
@@ -12,7 +12,7 @@ def process_single_url(url: str, output: str) -> None:
         Colors.print(f"Unsupported or invalid URL: {url}", Colors.FAIL)
         return
 
-    crawler = Crawler()
+    crawler = AltCrawler() if alt else Crawler()
     links = crawler.crawl(url)
     if not links:
         Colors.print("No links found.", Colors.FAIL)
@@ -26,8 +26,8 @@ def process_single_url(url: str, output: str) -> None:
         downloader.downloadUrls(path, item["links"])
 
 
-def process_batch(file_path: str, forced_type: str, output: str) -> None:
-    crawler = Crawler()
+def process_batch(file_path: str, forced_type: str, output: str, alt: bool = False) -> None:
+    crawler = AltCrawler() if alt else Crawler()
     downloader = Downloader()
 
     with open(file_path, "r") as f:
@@ -58,19 +58,20 @@ def process_batch(file_path: str, forced_type: str, output: str) -> None:
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Fancaps Downloader CLI",
-        usage="python -m fancaps.cli [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE]",
+        usage="python -m fancaps.cli [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE] [--alt]",
     )
     parser.add_argument("url", nargs="?", help="Single URL Mode (season/movie/episode)")
     parser.add_argument("--output", type=str, default="Downloads", help="Target folder for downloads")
     parser.add_argument("--batch-type", type=str, choices=["season", "movie"], help="Type of downloads (optional)")
     parser.add_argument("--batch-file", type=str, help="Path to txt file of URLs")
+    parser.add_argument("--alt", action="store_true", help="Use alternative crawler")
 
     args = parser.parse_args(argv)
 
     if args.batch_file:
-        process_batch(args.batch_file, args.batch_type, args.output)
+        process_batch(args.batch_file, args.batch_type, args.output, args.alt)
     elif args.url:
-        process_single_url(args.url, args.output)
+        process_single_url(args.url, args.output, args.alt)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- support `--alt` for CLI to use `AltCrawler`
- document the new option in README

## Testing
- `python -m fancaps.cli --help`
- `python -m fancaps.cli --alt https://example.com`
- `python -m fancaps.cli --batch-file sample.txt --alt`

------
https://chatgpt.com/codex/tasks/task_e_6855bff5c2a4833394856c440fd0b73a