### PR TITLE
Improve alt crawler parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ https://fancaps.net/movies/MovieImages.php?...
 ```
 Wrap URLs containing `&` in quotes.
 Use `--alt` to activate the alternative crawler for season or episode URLs.
+The alternative crawler now downloads picture pages concurrently for faster
+processing. When using the library directly you may pass a `max_workers`
+parameter to `AltCrawler.crawl()` to control the level of parallelism.
 
 ## Notes
 - `queue.txt` is writable via the web interface, `archive.txt` is read only.


### PR DESCRIPTION
## Summary
- use ThreadPoolExecutor in AltEpisodeCrawler and AltSeasonCrawler
- allow optional `max_workers` on alt crawling functions
- note new alt crawler option in README

## Testing
- `python fancaps-downloader.py --help`
- `timeout 2 python fancaps-daemon.py`

------
https://chatgpt.com/codex/tasks/task_e_68565e083f888333972fadc7f88081fd