### PR TITLE
Limit alt crawler workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ pip install -r requirements.txt
 Run the downloader directly:
 
 ```bash
-python fancaps-downloader.py [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE] [--alt]
+python fancaps-downloader.py [URL] [--output DIR] [--batch-type {season,movie}] \
+    [--batch-file FILE] [--alt] [--workers N]
 ```
 
 Supported links:
@@ -59,9 +60,10 @@ https://fancaps.net/movies/MovieImages.php?...
 ```
 Wrap URLs containing `&` in quotes.
 Use `--alt` to activate the alternative crawler for season or episode URLs.
-The alternative crawler now downloads picture pages concurrently for faster
-processing. When using the library directly you may pass a `max_workers`
-parameter to `AltCrawler.crawl()` to control the level of parallelism.
+The alternative crawler downloads picture pages concurrently for faster
+processing. It defaults to **10** workers to avoid exhausting file handles.
+When using the library directly you may pass a `max_workers` parameter or the
+`--workers` option on the CLI to control the level of parallelism.
 
 ## Notes
 - `queue.txt` is writable via the web interface, `archive.txt` is read only.

--- a/fancaps/cli.py
+++ b/fancaps/cli.py
@@ -2,9 +2,11 @@
 import argparse
 import os
 from . import Crawler, AltCrawler, Downloader, Colors, UrlSupport
+from scraper.alt_crawler import DEFAULT_MAX_WORKERS
 
 
-def process_single_url(url: str, output: str, alt: bool = False) -> None:
+def process_single_url(url: str, output: str, alt: bool = False,
+                       workers: int = DEFAULT_MAX_WORKERS) -> None:
     url_type = UrlSupport().getType(url)
     Colors.print(f"URL-Typ: {url_type}", Colors.CYAN)
 
@@ -13,7 +15,7 @@ def process_single_url(url: str, output: str, alt: bool = False) -> None:
         return
 
     crawler = AltCrawler() if alt else Crawler()
-    links = crawler.crawl(url)
+    links = crawler.crawl(url, max_workers=workers)
     if not links:
         Colors.print("No links found.", Colors.FAIL)
         return
@@ -26,7 +28,8 @@ def process_single_url(url: str, output: str, alt: bool = False) -> None:
         downloader.downloadUrls(path, item["links"])
 
 
-def process_batch(file_path: str, forced_type: str, output: str, alt: bool = False) -> None:
+def process_batch(file_path: str, forced_type: str, output: str,
+                  alt: bool = False, workers: int = DEFAULT_MAX_WORKERS) -> None:
     crawler = AltCrawler() if alt else Crawler()
     downloader = Downloader()
 
@@ -41,7 +44,7 @@ def process_batch(file_path: str, forced_type: str, output: str, alt: bool = Fal
             Colors.print(f"[{idx}] Unsupported or invalid URL: {url}", Colors.FAIL)
             continue
 
-        links = crawler.crawl(url)
+        links = crawler.crawl(url, max_workers=workers)
         if not links:
             Colors.print("No links found.", Colors.WARNING)
             continue
@@ -58,20 +61,26 @@ def process_batch(file_path: str, forced_type: str, output: str, alt: bool = Fal
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Fancaps Downloader CLI",
-        usage="python -m fancaps.cli [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE] [--alt]",
+        usage="python -m fancaps.cli [URL] [--output DIR] [--batch-type {season,movie}] [--batch-file FILE] [--alt] [--workers N]",
     )
     parser.add_argument("url", nargs="?", help="Single URL Mode (season/movie/episode)")
     parser.add_argument("--output", type=str, default="Downloads", help="Target folder for downloads")
     parser.add_argument("--batch-type", type=str, choices=["season", "movie"], help="Type of downloads (optional)")
     parser.add_argument("--batch-file", type=str, help="Path to txt file of URLs")
     parser.add_argument("--alt", action="store_true", help="Use alternative crawler")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=DEFAULT_MAX_WORKERS,
+        help=f"Number of concurrent workers (default: {DEFAULT_MAX_WORKERS})",
+    )
 
     args = parser.parse_args(argv)
 
     if args.batch_file:
-        process_batch(args.batch_file, args.batch_type, args.output, args.alt)
+        process_batch(args.batch_file, args.batch_type, args.output, args.alt, args.workers)
     elif args.url:
-        process_single_url(args.url, args.output, args.alt)
+        process_single_url(args.url, args.output, args.alt, args.workers)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- set default worker limit for alternative crawler to avoid open file exhaustion
- allow customizing concurrency with `--workers`
- document worker option in README

## Testing
- `pip install -q -r requirements.txt`
- `python fancaps-downloader.py -h`

------
https://chatgpt.com/codex/tasks/task_e_685662ec04e883338728c04a73b89004