### PR TITLE
Fix pylint issues in core modules

### DIFF
--- a/fancaps/cli.py
+++ b/fancaps/cli.py
@@ -30,7 +30,7 @@ def process_batch(file_path: str, forced_type: str, output: str, alt: bool = Fal
     crawler = AltCrawler() if alt else Crawler()
     downloader = Downloader()
 
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         urls = [line.strip() for line in f if line.strip()]
 
     Colors.print(f"Batch started: {len(urls)} URLs", Colors.CYAN)

--- a/fancaps/daemon.py
+++ b/fancaps/daemon.py
@@ -22,21 +22,21 @@ setattr(Colors, "print", lambda msg, *_: logging.info(msg))
 def read_first_url():
     if not os.path.exists(QUEUE_FILE):
         return None
-    with open(QUEUE_FILE, "r") as f:
+    with open(QUEUE_FILE, "r", encoding="utf-8") as f:
         lines = [line.strip() for line in f if line.strip()]
     return lines[0] if lines else None
 
 
 def remove_url_from_queue(url: str) -> None:
-    with open(QUEUE_FILE, "r") as f:
+    with open(QUEUE_FILE, "r", encoding="utf-8") as f:
         lines = [line.strip() for line in f if line.strip()]
     lines = [line for line in lines if line != url]
-    with open(QUEUE_FILE, "w") as f:
+    with open(QUEUE_FILE, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + ("\n" if lines else ""))
 
 
 def append_to_archive(url: str) -> None:
-    with open(ARCHIVE_FILE, "a") as f:
+    with open(ARCHIVE_FILE, "a", encoding="utf-8") as f:
         f.write(url + "\n")
 
 

--- a/scraper/alt_crawler.py
+++ b/scraper/alt_crawler.py
@@ -1,3 +1,5 @@
+"""Alternative crawler implementation for Fancaps."""
+
 import re
 import os
 from bs4 import BeautifulSoup

--- a/scraper/crawler.py
+++ b/scraper/crawler.py
@@ -1,3 +1,5 @@
+"""Primary crawler for Fancaps URLs."""
+
 from scraper.url_support import UrlSupport
 from scraper.crawlers import episode_crawler, season_crawler, movie_crawler
 from scraper.utils.colors import Colors

--- a/scraper/crawlers/movie_crawler.py
+++ b/scraper/crawlers/movie_crawler.py
@@ -1,3 +1,5 @@
+"""Crawler for movie screenshots."""
+
 import re
 from bs4 import BeautifulSoup
 import cloudscraper
@@ -43,7 +45,7 @@ class MovieCrawler:
                     alt = imgAlt
                 if alt == imgAlt:
                     picLinks.append(thumb_to_cdn(imgSrc))
-            
+
             try:
                 # Generate and verify the existence of the next page URL
                 next = url.replace(f'https://fancaps.net/movies/','') +f"&page={pageNumber + 1}"
@@ -56,9 +58,8 @@ class MovieCrawler:
             except Exception as e:
                 print(f"Error processing next page: {e}")
                 break
-        
+
         return {
             'subfolder': subfolder,
             'links': picLinks
         }
-

--- a/scraper/crawlers/season_crawler.py
+++ b/scraper/crawlers/season_crawler.py
@@ -1,3 +1,5 @@
+"""Crawler for TV and anime seasons."""
+
 from bs4 import BeautifulSoup
 from scraper.crawlers import episode_crawler
 import re
@@ -28,10 +30,10 @@ class SeasonCrawler:
                 Colors.print(f"Error occurred while fetching the page: {e}", Colors.RED)
                 break
 
-            for DOMLink in beautifulSoup.find_all('a', class_='btn', href=re.compile("^.*?/episodeimages.php\?")):
+            for DOMLink in beautifulSoup.find_all('a', class_='btn', href=re.compile(r"^.*?/episodeimages.php\?")):
                 href = DOMLink.get('href')
                 if href:
-                    if not re.match("^https://.*?/episodeimages.php\?", href):
+                    if not re.match(r"^https://.*?/episodeimages.php\?", href):
                         href = 'https://fancaps.net' + DOMLink.get('href')
 
                     match = re.search(r"https://fancaps.net/.*?/episodeimages.php\?\d+-(.*?)/", href)
@@ -56,4 +58,3 @@ class SeasonCrawler:
                 Colors.print(f"Failed to crawl {epLink}: {e}", Colors.RED)
 
         return picLinks
-

--- a/web/fancaps_web.py
+++ b/web/fancaps_web.py
@@ -9,11 +9,11 @@ ARCHIVE_FILE = "/opt/fancaps/archive.txt"
 def read_lines(path):
     if not os.path.exists(path):
         return []
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         return [line.strip() for line in f if line.strip()]
 
 def write_lines(path, lines):
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
 
 @app.route("/", methods=["GET", "POST"])
@@ -24,7 +24,7 @@ def index():
             alt = "alt_scraper" in request.form
             if url:
                 entry = f"ALT|{url}" if alt else url
-                with open(QUEUE_FILE, "a") as f:
+                with open(QUEUE_FILE, "a", encoding="utf-8") as f:
                     f.write(entry + "\n")
         elif "delete_url" in request.form:
             url_to_delete = request.form.get("delete_url", "").strip()


### PR DESCRIPTION
## Summary
- address pylint warnings for encoding
- improve regex strings to avoid escape issues
- add missing module docstrings
- clean whitespace

## Testing
- `pylint fancaps-downloader.py fancaps-daemon.py fancaps scraper web`
- `python -m fancaps.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_6859408b3a848333a103b758e26eb779